### PR TITLE
feat(TD-22): Delete task from backend

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class TasksController < ApplicationController
-      before_action :set_task, only: [:show, :update, :update_completion]
+      before_action :set_task, only: [:show, :update, :update_completion, :destroy]
 
       def index
         result = PaginationService.paginate(Task, params)
@@ -84,6 +84,17 @@ module Api
             @task,
             metadata: metadata
           ), status: :ok
+        else
+          render json: TaskSerializer.serialize_errors(
+            @task.errors.full_messages,
+            metadata: metadata
+          ), status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @task.destroy
+          render json: { message: "Task successfully deleted", metadata: metadata }, status: :ok
         else
           render json: TaskSerializer.serialize_errors(
             @task.errors.full_messages,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :tasks, only: [:index, :show, :create, :update] do
-        member do
-          patch :update_completion
-        end
+      resources :tasks, only: [:index, :show, :create, :update, :destroy] do
+        patch :update_completion, on: :member
       end
     end
   end


### PR DESCRIPTION
**Description of change**

- Tasks can be deleted in the backend

**Associated Trello link**

https://trello.com/c/eD6t59Ec

**Screenshot of change**

I can use the following curl command to delete a task in the backend by its ID:
```
curl -X DELETE http://localhost:3001/api/v1/tasks/59 \
-H "Content-Type: application/json"
```

The task gets deleted in the backend:

<img width="555" alt="Screenshot 2024-12-19 at 7 23 45 AM" src="https://github.com/user-attachments/assets/cf980dbe-f247-4290-905e-3e6c3d48de39" />

**Dev notes**

Frontend has been updated to delete tasks and update task list using this API